### PR TITLE
Add support for older browsers that don't support ES6 and beyond.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const tokenCache = require('./token-cache');
+var tokenCache = require('./token-cache');
 
 function getToken(options) {
   if (options.token) {
     return Promise.resolve(options.token);
   }
 
-  const token = options.getToken();
+  var token = options.getToken();
   if (typeof token !== 'object' || !token.then) {
     return Promise.resolve(token);
   }
@@ -14,14 +14,14 @@ function getToken(options) {
 }
 
 module.exports = function tokenInterceptor(options) {
-  const header = options.header || 'Authorization';
-  const headerFormatter = options.headerFormatter || function defaultHeaderFormatter(token) {
-    return `Bearer ${token}`;
+  var header = options.header || 'Authorization';
+  var headerFormatter = options.headerFormatter || function defaultHeaderFormatter(token) {
+    return 'Bearer ' + token;
   };
 
   return function interceptRequest(config) {
-    const requestConfig = config;
-    return getToken(options).then((token) => {
+    var requestConfig = config;
+    return getToken(options).then(function (token) {
       requestConfig.headers[header] = headerFormatter(token);
       return config;
     });

--- a/token-cache.js
+++ b/token-cache.js
@@ -1,23 +1,23 @@
-const Lock = require('lock');
+var Lock = require('lock');
 
-module.exports = (getToken, options) => {
-  const lock = Lock();
-  const getMaxAge = options.getMaxAge || function getMaxAge() {
+module.exports = function (getToken, options) {
+  var lock = Lock();
+  var getMaxAge = options.getMaxAge || function getMaxAge() {
     return options.maxAge || 0;
   };
 
-  let cachedToken = null;
-  let cacheExpiration = null;
+  var cachedToken = null;
+  var cacheExpiration = null;
 
-  const cache = function getFromCache() {
+  var cache = function getFromCache() {
     if (cachedToken && cacheExpiration && cacheExpiration - Date.now() > 0) {
       return Promise.resolve(cachedToken);
     }
 
     // Get a new token and prevent concurrent request.
-    return new Promise((resolve, reject) => {
-      lock('cache', (unlockFn) => {
-        const unlock = unlockFn();
+    return new Promise(function (resolve, reject) {
+      lock('cache', function (unlockFn) {
+        var unlock = unlockFn();
 
         // Token was already loaded by the previous lock.
         if (cachedToken && cacheExpiration && cacheExpiration - Date.now() > 0) {
@@ -27,13 +27,13 @@ module.exports = (getToken, options) => {
 
         // Get the token.
         return getToken()
-          .then((token) => {
+          .then(function (token) {
             cachedToken = token;
             cacheExpiration = Date.now() + (getMaxAge(token));
             unlock();
             resolve(token);
           })
-          .catch((err) => {
+          .catch(function (err) {
             unlock();
             reject(err);
           });


### PR DESCRIPTION
If you run UglifyJS using this library it will complain about both backticks, lambda functions and invalid assignments and more. This PR changes that, by adding support for older browsers and using babel stage-2 presets. Tested and verified on a larger application.