### PR TITLE
Fix token cache documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Now it could also be that the token itself contains the expiration time (this is
 
 ```js
 const cache = tokenProvider.tokenCache(
-  getTokenFromAuthorizationServer().then(res => res.body),
-  { getMaxAge: (res) => res.expires_in }
+  () => getTokenFromAuthorizationServer().then(res => res.body),
+  { getMaxAge: (body) => body.expires_in }
 );
 
 instance.interceptors.request.use(tokenProvider({
   getToken: cache,
-  headerFormatter: (res) => 'Bearer ' + res.access_token,
+  headerFormatter: (body) => 'Bearer ' + body.access_token,
 }));
 ```
 


### PR DESCRIPTION
- Fix the usage
- Rename some `res` variables to `body`, because that's what it is and it helps reduce confusion.
Fixes issue #2