### PR TITLE
cacheExpiration: getMaxAge is in seconds

### DIFF
--- a/token-cache.js
+++ b/token-cache.js
@@ -29,7 +29,7 @@ module.exports = (getToken, options) => {
         return getToken()
           .then((token) => {
             cachedToken = token;
-            cacheExpiration = Date.now() + (getMaxAge(token));
+            cacheExpiration = Date.now() + (getMaxAge(token) * 1000);
             unlock();
             resolve(token);
           })


### PR DESCRIPTION
The token is immediately expired if you have 3600 seconds, but interpreted as milliseconds